### PR TITLE
Setting up automapper, IDispose was removed in BaseRepository.cs and …

### DIFF
--- a/src/the-office.api.application/Characters/Handlers/CharacterHandler.cs
+++ b/src/the-office.api.application/Characters/Handlers/CharacterHandler.cs
@@ -1,6 +1,7 @@
 ﻿using the_office.api.application.Characters.Requests;
 using the_office.api.application.Characters.Responses;
 using the_office.domain.Interface;
+using the_office.domain.Repositories;
 using the_office.insfrastructure.Mediator.Message;
 
 namespace the_office.api.application.Characters.Handlers

--- a/src/the-office.api.application/Common/AssemblyReference.cs
+++ b/src/the-office.api.application/Common/AssemblyReference.cs
@@ -1,0 +1,8 @@
+using System.Reflection;
+
+namespace the_office.api.application.Common;
+
+public static class AssemblyReference
+{
+    public static readonly Assembly Assembly = typeof(AssemblyReference).Assembly;
+}

--- a/src/the-office.api.application/Common/Mappings/IMapFrom.cs
+++ b/src/the-office.api.application/Common/Mappings/IMapFrom.cs
@@ -1,0 +1,8 @@
+using AutoMapper;
+
+namespace the_office.api.application.Common.Mappings;
+
+public interface IMapFrom<T>
+{
+    void Mapping(Profile profile) => profile.CreateMap(typeof(T), GetType());
+}

--- a/src/the-office.api.application/Common/Mappings/MappingProfile.cs
+++ b/src/the-office.api.application/Common/Mappings/MappingProfile.cs
@@ -1,0 +1,30 @@
+using System.Reflection;
+using AutoMapper;
+
+namespace the_office.api.application.Common.Mappings;
+
+public class MappingProfile : Profile
+{
+    public MappingProfile()
+    {
+        ApplyMappingsFromAssembly(Assembly.GetExecutingAssembly());
+    }
+    
+    private void ApplyMappingsFromAssembly(Assembly assembly)
+    {
+        var types = assembly.GetExportedTypes()
+            .Where(t => t.GetInterfaces().Any(i =>
+                i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IMapFrom<>)))
+            .ToList();
+
+        foreach (var type in types)
+        {
+            var instance = Activator.CreateInstance(type);
+
+            var methodInfo = type.GetMethod("Mapping")
+                             ?? type.GetInterface("IMapFrom`1")!.GetMethod("Mapping");
+
+            methodInfo?.Invoke(instance, new object[] { this });
+        }
+    }
+}

--- a/src/the-office.api.application/Episodes/Handlers/EpisodeHandler.cs
+++ b/src/the-office.api.application/Episodes/Handlers/EpisodeHandler.cs
@@ -1,6 +1,6 @@
 ﻿using the_office.api.application.Episodes.Requests;
 using the_office.api.application.Episodes.Responses;
-using the_office.domain.Interface;
+using the_office.domain.Repositories;
 using the_office.insfrastructure.Mediator.Message;
 
 namespace the_office.api.application.Episodes.Handlers

--- a/src/the-office.api.application/Episodes/Handlers/GetEpisodeByIdHandler.cs
+++ b/src/the-office.api.application/Episodes/Handlers/GetEpisodeByIdHandler.cs
@@ -1,0 +1,33 @@
+using AutoMapper;
+using the_office.api.application.Episodes.Requests;
+using the_office.api.application.Episodes.Responses;
+using the_office.domain.Repositories;
+using the_office.insfrastructure.Mediator.Message;
+
+namespace the_office.api.application.Episodes.Handlers;
+
+public class GetEpisodeByIdHandler : CommandHandler<GetEpisodeByIdRequest, EpisodeResponse>
+{
+    private readonly IEpisodeRepository _episodeRepository;
+    private readonly IMapper _mapper;
+
+    public GetEpisodeByIdHandler(IEpisodeRepository episodeRepository, IMapper mapper)
+    {
+        _episodeRepository = episodeRepository;
+        _mapper = mapper;
+    }
+
+    public override async Task<CommandResponse<EpisodeResponse>> Handle(GetEpisodeByIdRequest request, CancellationToken cancellationToken)
+    {
+        var episode = await _episodeRepository.Get(request.Id);
+
+        // TODO: Need to refactor this for an appropriate result
+        if (episode is null)
+            return new CommandResponse<EpisodeResponse>(null, null, null);
+
+        var response = _mapper.Map<EpisodeResponse>(episode);
+
+        // TODO: Need simplify this CommandResponse creation
+        return new CommandResponse<EpisodeResponse>(response, null, null);
+    }
+}

--- a/src/the-office.api.application/Episodes/Requests/GetEpisodeByIdRequest.cs
+++ b/src/the-office.api.application/Episodes/Requests/GetEpisodeByIdRequest.cs
@@ -1,0 +1,14 @@
+using the_office.api.application.Episodes.Responses;
+using the_office.insfrastructure.Mediator.Message;
+
+namespace the_office.api.application.Episodes.Requests;
+
+public class GetEpisodeByIdRequest : CommandHandler<EpisodeResponse>
+{
+    public GetEpisodeByIdRequest(int id)
+    {
+        Id = id;
+    }
+
+    public int Id { get; }
+}

--- a/src/the-office.api.application/Episodes/Responses/EpisodeResponse.cs
+++ b/src/the-office.api.application/Episodes/Responses/EpisodeResponse.cs
@@ -1,6 +1,11 @@
-﻿namespace the_office.api.application.Episodes.Responses
+﻿using the_office.api.application.Common.Mappings;
+using the_office.domain.Entities;
+
+namespace the_office.api.application.Episodes.Responses;
+
+public class EpisodeResponse : IMapFrom<Episode>
 {
-    public class EpisodeResponse
-    {
-    }
+    public string Name { get; set; }
+    public string AirDate { get; set; }
+    public string Description { get; set; }
 }

--- a/src/the-office.api.application/Season/Handlers/SeasonHandler.cs
+++ b/src/the-office.api.application/Season/Handlers/SeasonHandler.cs
@@ -1,6 +1,6 @@
 ﻿using the_office.api.application.Season.Requests;
 using the_office.api.application.Season.Responses;
-using the_office.domain.Interface;
+using the_office.domain.Repositories;
 using the_office.insfrastructure.Mediator.Message;
 
 namespace the_office.api.application.Season.Handlers

--- a/src/the-office.api.application/the-office.api.application.csproj
+++ b/src/the-office.api.application/the-office.api.application.csproj
@@ -8,25 +8,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="Characters\Requests\Validations\**" />
-    <Compile Remove="Common\**" />
-    <Compile Remove="Episodes\Requests\Validations\**" />
-    <EmbeddedResource Remove="Characters\Requests\Validations\**" />
-    <EmbeddedResource Remove="Common\**" />
-    <EmbeddedResource Remove="Episodes\Requests\Validations\**" />
-    <None Remove="Characters\Requests\Validations\**" />
-    <None Remove="Common\**" />
-    <None Remove="Episodes\Requests\Validations\**" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\the-office.infrastructure\the-office.infrastructure.csproj" />
   </ItemGroup>
 
   <ItemGroup>
+    <Folder Include="Common\Behaviours\" />
+    <Folder Include="Common\Helpers\" />
     <Folder Include="Phrases\Handler\" />
     <Folder Include="Phrases\Responses\" />
     <Folder Include="Phrases\Requests\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="12.0.1" />
+  </ItemGroup>
 </Project>

--- a/src/the-office.api/Configurations/DependencyInjectionConfig.cs
+++ b/src/the-office.api/Configurations/DependencyInjectionConfig.cs
@@ -1,4 +1,5 @@
 ﻿using the_office.domain.Interface;
+using the_office.domain.Repositories;
 using the_office.infrastructure.Data.Repositories;
 
 namespace the_office.api.Configurations
@@ -7,6 +8,18 @@ namespace the_office.api.Configurations
     {
         public static void ResolveDependencies(this IServiceCollection services)
         {
+            services.AddMediatR(config =>
+            {
+                config.RegisterServicesFromAssembly(application.Common.AssemblyReference.Assembly);
+            
+                // TODO: For future implementation
+                // Mediator Behaviors
+                // config.AddBehavior(typeof(IPipelineBehavior<,>), typeof(UnhandledExceptionBehaviour<,>));
+                // config.AddBehavior(typeof(IPipelineBehavior<,>), typeof(ValidationBehaviour<,>));
+            });
+            
+            services.AddAutoMapper(application.Common.AssemblyReference.Assembly);
+            
             services.AddScoped<ICharacterRepository, CharacterRepository>();
             services.AddScoped<IEpisodeRepository, EpisodeRepository>();
             services.AddScoped<IPhrasesRepository, PhrasesRepository>();

--- a/src/the-office.api/Controllers/CharactersController.cs
+++ b/src/the-office.api/Controllers/CharactersController.cs
@@ -1,6 +1,6 @@
 ﻿using MediatR;
 using Microsoft.AspNetCore.Mvc;
-using Swashbuckle.AspNetCore.Examples;
+using Swashbuckle.AspNetCore.Filters;
 using the_office.api.application.Characters.Requests;
 using the_office.api.ModelExamples;
 using the_office.domain.Response;

--- a/src/the-office.api/Controllers/EpisodesController.cs
+++ b/src/the-office.api/Controllers/EpisodesController.cs
@@ -1,16 +1,34 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using the_office.api.application.Episodes.Requests;
 
 namespace the_office.api.Controllers
 {
     [ApiController]
-    [Route("episode")]
+    [Route("episodes")]
     public class EpisodesController : ControllerBase
     {
+        private readonly IMediator _mediator;
+
+        public EpisodesController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
         [HttpGet]
-        [Route("GetAll")]
-        public ActionResult Index()
+        public ActionResult Get()
         {
             throw new NotImplementedException();
+        }
+        
+        [HttpGet("{id:int}")]
+        public async Task<ActionResult> GetById([FromRoute] int id)
+        {
+            var request = new GetEpisodeByIdRequest(id);
+            
+            var response = await _mediator.Send(request);
+            
+            return Ok(response.Result);
         }
     }
 }

--- a/src/the-office.api/the-office.api.csproj
+++ b/src/the-office.api/the-office.api.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.5">
       <PrivateAssets>all</PrivateAssets>
@@ -27,9 +28,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="NBuilder" Version="6.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Examples" Version="2.9.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.6" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.5.0" />
   </ItemGroup>

--- a/src/the-office.domain/Common/Entity.cs
+++ b/src/the-office.domain/Common/Entity.cs
@@ -1,4 +1,4 @@
-﻿namespace the_office.domain.Model
+﻿namespace the_office.domain.Common
 {
     public class Entity
     {

--- a/src/the-office.domain/Entities/Character.cs
+++ b/src/the-office.domain/Entities/Character.cs
@@ -1,4 +1,4 @@
-﻿using the_office.domain.Model;
+﻿using the_office.domain.Common;
 
 namespace the_office.domain.Entities
 {

--- a/src/the-office.domain/Entities/Episode.cs
+++ b/src/the-office.domain/Entities/Episode.cs
@@ -1,4 +1,4 @@
-﻿using the_office.domain.Model;
+﻿using the_office.domain.Common;
 
 namespace the_office.domain.Entities
 {

--- a/src/the-office.domain/Entities/Phrases.cs
+++ b/src/the-office.domain/Entities/Phrases.cs
@@ -1,4 +1,4 @@
-﻿using the_office.domain.Model;
+﻿using the_office.domain.Common;
 
 namespace the_office.domain.Entities
 {

--- a/src/the-office.domain/Entities/Season.cs
+++ b/src/the-office.domain/Entities/Season.cs
@@ -1,4 +1,4 @@
-﻿using the_office.domain.Model;
+﻿using the_office.domain.Common;
 
 namespace the_office.domain.Entities
 {

--- a/src/the-office.domain/Repositories/IBaseRepository.cs
+++ b/src/the-office.domain/Repositories/IBaseRepository.cs
@@ -1,8 +1,8 @@
-﻿using the_office.domain.Model;
+﻿using the_office.domain.Common;
 
-namespace the_office.domain.Interface
+namespace the_office.domain.Repositories
 {
-    public interface IBaseRepository<TEntity> : IDisposable where TEntity : Entity
+    public interface IBaseRepository<TEntity> where TEntity : Entity
     {
         Task<TEntity> GetById(int id);
 

--- a/src/the-office.domain/Repositories/ICharacterRepository.cs
+++ b/src/the-office.domain/Repositories/ICharacterRepository.cs
@@ -1,6 +1,6 @@
 ﻿using the_office.domain.Entities;
 
-namespace the_office.domain.Interface
+namespace the_office.domain.Repositories
 {
     public interface ICharacterRepository : IBaseRepository<Character>
     {

--- a/src/the-office.domain/Repositories/IEpisodeRepository.cs
+++ b/src/the-office.domain/Repositories/IEpisodeRepository.cs
@@ -1,6 +1,9 @@
-﻿namespace the_office.domain.Interface
+﻿using the_office.domain.Entities;
+
+namespace the_office.domain.Repositories
 {
     public interface IEpisodeRepository
     {
+        Task<Episode?> Get(int id);
     }
 }

--- a/src/the-office.domain/Repositories/ISeasonRepository.cs
+++ b/src/the-office.domain/Repositories/ISeasonRepository.cs
@@ -1,6 +1,6 @@
 ﻿using the_office.domain.Entities;
 
-namespace the_office.domain.Interface
+namespace the_office.domain.Repositories
 {
     public interface ISeasonRepository : IBaseRepository<Season>
     {

--- a/src/the-office.infrastructure/Data/Repositories/BaseRepository.cs
+++ b/src/the-office.infrastructure/Data/Repositories/BaseRepository.cs
@@ -1,5 +1,5 @@
-﻿using the_office.domain.Interface;
-using the_office.domain.Model;
+﻿using the_office.domain.Common;
+using the_office.domain.Repositories;
 
 namespace the_office.infrastructure.Data.Repositories
 {
@@ -23,12 +23,6 @@ namespace the_office.infrastructure.Data.Repositories
         public Task<int> SaveChanges()
         {
             throw new NotImplementedException();
-        }
-
-        public void Dispose()
-        {
-            throw new NotImplementedException();
-            //Db?.Dispose
         }
     }
 }

--- a/src/the-office.infrastructure/Data/Repositories/CharacterRepository.cs
+++ b/src/the-office.infrastructure/Data/Repositories/CharacterRepository.cs
@@ -1,5 +1,6 @@
 ﻿using the_office.domain.Entities;
 using the_office.domain.Interface;
+using the_office.domain.Repositories;
 
 namespace the_office.infrastructure.Data.Repositories
 {

--- a/src/the-office.infrastructure/Data/Repositories/EpisodeRepository.cs
+++ b/src/the-office.infrastructure/Data/Repositories/EpisodeRepository.cs
@@ -1,9 +1,20 @@
 ﻿using the_office.domain.Entities;
-using the_office.domain.Interface;
+using the_office.domain.Repositories;
 
 namespace the_office.infrastructure.Data.Repositories
 {
     public class EpisodeRepository : BaseRepository<Episode>, IEpisodeRepository
     {
+        public async Task<Episode?> Get(int id)
+        {
+            var episode = new Episode
+            {
+                Id = id,
+                Name = "Health Care",
+                Description = "Episode description"
+            };
+
+            return await Task.FromResult(episode);
+        }
     }
 }

--- a/src/the-office.infrastructure/Data/Repositories/SeasonRepository.cs
+++ b/src/the-office.infrastructure/Data/Repositories/SeasonRepository.cs
@@ -1,5 +1,5 @@
 ﻿using the_office.domain.Entities;
-using the_office.domain.Interface;
+using the_office.domain.Repositories;
 
 namespace the_office.infrastructure.Data.Repositories
 {


### PR DESCRIPTION
- Setting up automapper
- IDispose was removed in BaseRepository.cs 
- Remove deprecated library Swashbuckle.AspNetCore.Examples
- Fixed some namespaces