### PR TITLE
Feature/error logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ appsettings.json
 *.user
 *.suo
 *.userprefs
-/src/the-office.api/appsettings.json
 /src/the-office.api/appsettings.Development.json
 /src/the-office.api/appsettings.Development.json
 /src/the-office.api/appsettings.json

--- a/src/the-office.api.application/Common/Behaviors/LoggingBehavior.cs
+++ b/src/the-office.api.application/Common/Behaviors/LoggingBehavior.cs
@@ -1,0 +1,40 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using the_office.domain.Shared;
+
+namespace the_office.api.application.Common.Behaviors;
+
+public class LoggingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : IRequest<TResponse>
+    where TResponse : Result
+{
+    private readonly ILogger<LoggingBehavior<TRequest, TResponse>> _logger;
+
+    public LoggingBehavior(ILogger<LoggingBehavior<TRequest, TResponse>> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Starting request: {@RequestName} - {@DateTimeUtc}",
+            typeof(TRequest).Name,
+            DateTime.UtcNow);
+
+        var result = await next();
+
+        if (result.IsFailure)
+        {
+            _logger.LogWarning("Request failure: {@RequestName} - {@Error} - {@DateTimeUtc}",
+                typeof(TRequest).Name,
+                result.Error,
+                DateTime.UtcNow);
+        }
+        
+        _logger.LogInformation("Completed request: {@RequestName} - {@DateTimeUtc}",
+            typeof(TRequest).Name,
+            DateTime.UtcNow);
+
+        return result;
+    }
+}

--- a/src/the-office.api/Configurations/DependencyInjectionConfig.cs
+++ b/src/the-office.api/Configurations/DependencyInjectionConfig.cs
@@ -16,6 +16,7 @@ public static class DependencyInjectionConfig
         {
             config.RegisterServicesFromAssembly(AssemblyReference.Assembly);
             config.AddBehavior(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
+            config.AddBehavior(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));
         });
         
         services.AddValidatorsFromAssembly(AssemblyReference.Assembly, includeInternalTypes: true);

--- a/src/the-office.api/Configurations/SerilogConfig.cs
+++ b/src/the-office.api/Configurations/SerilogConfig.cs
@@ -1,0 +1,14 @@
+using Serilog;
+
+namespace the_office.api.Configurations;
+
+public static class SerilogConfig
+{
+    public static IHostBuilder AddSerilogConfiguration(this IHostBuilder hostBuilder, IConfiguration configuration)
+    {
+        hostBuilder.UseSerilog((context, configureLogger) => 
+            configureLogger.ReadFrom.Configuration(configuration));
+
+        return hostBuilder;
+    }
+}

--- a/src/the-office.api/Filters/ApiExceptionFilterAttribute.cs
+++ b/src/the-office.api/Filters/ApiExceptionFilterAttribute.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace the_office.api.Filters;
+
+public class ApiExceptionFilterAttribute : ExceptionFilterAttribute
+{
+    private readonly ILogger<ApiExceptionFilterAttribute> _logger;
+
+    public ApiExceptionFilterAttribute(ILogger<ApiExceptionFilterAttribute> logger)
+    {
+        _logger = logger;
+    }
+
+    public override Task OnExceptionAsync(ExceptionContext context)
+    {
+        _logger.LogError(context.Exception, "Request failure: {@HttpMethod} {@Request}", context.HttpContext.Request.Method, context.HttpContext.Request.Path.Value);
+        
+        var details = new ProblemDetails
+        {
+            Status = StatusCodes.Status500InternalServerError,
+            Title = "An error occurred while processing your request.",
+            Type = "https://tools.ietf.org/html/rfc7231#section-6.6.1"
+        };
+
+        context.Result = new ObjectResult(details)
+        {
+            StatusCode = StatusCodes.Status500InternalServerError
+        };
+
+        context.ExceptionHandled = true;
+        
+        return base.OnExceptionAsync(context);
+    }
+}

--- a/src/the-office.api/Program.cs
+++ b/src/the-office.api/Program.cs
@@ -4,7 +4,6 @@ using the_office.api.Filters;
 using the_office.api.Infrastructure.HealthChecks;
 
 var builder = WebApplication.CreateBuilder(args);
-builder.Configuration.AddJsonFile("appsettings.json");
 
 builder.Services.AddDatabaseConfiguration(builder.Configuration);
 

--- a/src/the-office.api/Program.cs
+++ b/src/the-office.api/Program.cs
@@ -1,3 +1,4 @@
+using Serilog;
 using the_office.api.Configurations;
 using the_office.api.Filters;
 using the_office.api.Infrastructure.HealthChecks;
@@ -7,7 +8,11 @@ builder.Configuration.AddJsonFile("appsettings.json");
 
 builder.Services.AddDatabaseConfiguration(builder.Configuration);
 
-builder.Services.AddControllers(options => options.Filters.Add<AfterHandlerActionFilterAttribute>());
+builder.Services.AddControllers(options =>
+    {
+        options.Filters.Add<AfterHandlerActionFilterAttribute>();
+        options.Filters.Add<ApiExceptionFilterAttribute>();
+    });
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
@@ -16,15 +21,18 @@ builder.Services.ResolveDependencies(builder.Host);
 // Swagger Config
 builder.Services.AddSwaggerConfiguration();
 
+// Serilog Config
+builder.Host.AddSerilogConfiguration(builder.Configuration);
+    
 var app = builder.Build();
 
 app.UseSwaggerSetup();
 
 // app.UseHealthChecks();
 
-app.UseHttpsRedirection();
+app.UseSerilogRequestLogging();
 
-app.UseAuthorization();
+app.UseHttpsRedirection();
 
 app.MapControllers();
 

--- a/src/the-office.api/appsettings.json
+++ b/src/the-office.api/appsettings.json
@@ -1,0 +1,19 @@
+{
+  "ConnectionStrings": {
+    "TheOfficeConnectionString": "{connection-string}"
+  },
+  "Serilog": {
+    "Using": ["Serilog.Sinks.Console"],
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Information",
+        "System": "Information"
+      }
+    },
+    "WriteTo": [
+      { "Name":  "Console" }
+    ],
+    "Enrich": ["FromLogContext", "WithMachineName", "WithThreadId"]
+  }
+}

--- a/src/the-office.api/the-office.api.csproj
+++ b/src/the-office.api/the-office.api.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="NBuilder" Version="6.1.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.6" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.5.0" />


### PR DESCRIPTION
- Add Serilog library as a logging framework
- Implement an error handler
- It was necessary add appsettings.json into version control because of Serilog configuration. In addition to that, it would be a good practice to create your own appsettings.Development.json and use appsettings.json as a template.